### PR TITLE
Traceback experiment

### DIFF
--- a/cmd/minigo/main.go
+++ b/cmd/minigo/main.go
@@ -38,7 +38,7 @@ func main() {
 func run(ctx context.Context, filename string, entryPoint string) error {
 	fset := token.NewFileSet()
 
-	node, err := parser.ParseFile(fset, filename, nil, parser.AllErrors)
+	node, err := parser.ParseFile(fset, filename, nil, parser.AllErrors|parser.SkipObjectResolution)
 	if err != nil {
 		return fmt.Errorf("failed to parse file: %w", err)
 	}

--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -40,7 +40,8 @@ func New(fset *token.FileSet, options ...func(*Interpreter)) *Interpreter {
 	}}}
 	i = &Interpreter{
 		fset: fset,
-		evaluator: &evaluator{stdout: stdout, stderr: stderr,
+		evaluator: &evaluator{
+			fset: fset, stdout: stdout, stderr: stderr,
 			packages: packages,
 			scope:    scope,
 		},
@@ -145,6 +146,7 @@ func (s *scope) Get(name string) (reflect.Value, bool) {
 }
 
 type evaluator struct {
+	fset   *token.FileSet
 	stdout io.Writer
 	stderr io.Writer
 

--- a/internal/interpreter/testdata/func.go
+++ b/internal/interpreter/testdata/func.go
@@ -16,7 +16,7 @@ func F(n int) int {
 }
 
 func G(n int) int {
-	return n + 10
+	return n + 10 + true
 }
 
 func H(n int) {


### PR DESCRIPTION
```
Error: unsupported types: int64 + bool

Traceback (most recent call first):
	File "./internal/interpreter/testdata/func.go", line 19, in G()
		return n + 10 + true
	File "./internal/interpreter/testdata/func.go", line 15, in F()
		return G(n) + G(n) + 10
time=2024-09-23T15:22:35.000+09:00 level=ERROR msg="failed to run" error="failed to eval stmt[6]: failed to eval expr: failed to eval argument[0]: failed to eval return expr: failed to eval binary expr lhs: failed to eval binary expr lhs: failed to eval return expr: unsupported types: int64 + bool"
```